### PR TITLE
Make subsample_size default a property

### DIFF
--- a/elements/snippets/snippet.getids.php
+++ b/elements/snippets/snippet.getids.php
@@ -13,7 +13,7 @@
 /* set default properties */
 $ids = (!empty($ids) || $ids === '0') ? explode(',', $ids) : array($modx->resource->get('id'));
 $depth = isset($depth) ? (integer) $depth : $scriptProperties['depth'];
-$sampleSize = (isset($sampleSize) && $sampleSize !== "") ? intval($sampleSize) : 10;
+$sampleSize = (isset($sampleSize) && $sampleSize !== "") ? intval($sampleSize) : $scriptProperties['subsample_size'];
 
 $ids = array_map('trim',$ids);
 $resIds = array();


### PR DESCRIPTION
Added a property call to line 14 to call a subsample_size property as the default value if none is provided.