### PR TITLE
Default settings to come from system settings

### DIFF
--- a/elements/snippets/snippet.getids.php
+++ b/elements/snippets/snippet.getids.php
@@ -12,8 +12,8 @@
 
 /* set default properties */
 $ids = (!empty($ids) || $ids === '0') ? explode(',', $ids) : array($modx->resource->get('id'));
-$depth = isset($depth) ? (integer) $depth : $scriptProperties['depth'];
-$sampleSize = (isset($sampleSize) && $sampleSize !== "") ? intval($sampleSize) : 10;
+$depth = isset($depth) ? (integer) $depth : $modx->getOption('getids.depth');
+$sampleSize = (isset($sampleSize) && $sampleSize !== "") ? intval($sampleSize) : $modx->getOption('getids.subsample_size');
 
 $ids = array_map('trim',$ids);
 $resIds = array();
@@ -137,4 +137,3 @@ if ($invert == 1) {
 };
 
 return $lstIds;
-//return ",".$lstIds.",";


### PR DESCRIPTION
Changes to pull default settings from system settings instead of snippet properties and hard coding  in the event they're not supplied in the original snippet call. Also removed a redundant return statement.